### PR TITLE
Fix wrong title in Cpp index.

### DIFF
--- a/docs/cpp/index.yml
+++ b/docs/cpp/index.yml
@@ -2,7 +2,7 @@
 title: C++ 语言文档
 summary: 了解如何使用 C++ 和 C++ 标准库。
 metadata:
-  title: C# 文档 - 入门、教程、参考。
+  title: C++ 文档 - 入门、教程、参考。
   description: 适用于 Microsoft C++ 和 Visual Studio 用户的 C++ 编程参考。
   ms.topic: landing-page
   ms.date: 05/08/2020


### PR DESCRIPTION
`C#` -> `C++`

建议的有用信息：
1.请参阅[快速入门本地化样式指南](https://docs.microsoft.com/globalization/localization/styleguides)，了解 Microsoft 风格指南中**最重要的十大规则**。
2.请参阅 [Microsoft 语言门户](https://www.microsoft.com/language)，查看各 Microsoft 产品的**标准化术语翻译**。
